### PR TITLE
Fix ArgumentError test expectation on Ruby 2.3

### DIFF
--- a/test/nodes/shared_node_examples.rb
+++ b/test/nodes/shared_node_examples.rb
@@ -4,7 +4,7 @@ shared_examples_for 'A Binary Node' do |node|
   describe 'construction' do
     it 'requires two arguments' do
       err = ->{ node.new }.must_raise ArgumentError
-      err.message.must_match %r{wrong number of arguments \(0 for 2\)}
+      err.message.must_match %r{wrong number of arguments (?:\(0 for 2\)|\(given 0, expected 2\))}
     end
 
     it 'creates a new instance' do


### PR DESCRIPTION
Ruby 2.3 changed the format of argument error exceptions. Use a matcher that matches both pre-2.3 and 2.3 messages.
